### PR TITLE
updated deprecated XML methods to the new v3 names

### DIFF
--- a/sp/etc-shibboleth/shibboleth2.xml
+++ b/sp/etc-shibboleth/shibboleth2.xml
@@ -72,7 +72,7 @@
         <!-- Example of remotely supplied batch of signed metadata. -->
         <!--
         <MetadataProvider type="XML" validate="true"
-	      uri="http://federation.org/federation-metadata.xml"
+	      url="http://federation.org/federation-metadata.xml"
               backingFilePath="federation-metadata.xml" reloadInterval="7200">
             <MetadataFilter type="RequireValidUntil" maxValidityInterval="2419200"/>
             <MetadataFilter type="Signature" certificate="fedsigner.pem"/>
@@ -85,10 +85,10 @@
 
         <!-- Example of locally maintained metadata. -->
         <!--
-        <MetadataProvider type="XML" validate="true" file="partner-metadata.xml"/>
+        <MetadataProvider type="XML" validate="true" path="partner-metadata.xml"/>
         -->
         
-        <MetadataProvider type="XML" validate="true" file="idp-metadata.xml"/>
+        <MetadataProvider type="XML" validate="true" path="idp-metadata.xml"/>
 
         <!-- Map to extract attributes from SAML assertions. -->
         <AttributeExtractor type="XML" validate="true" reloadChanges="false" path="attribute-map.xml"/>


### PR DESCRIPTION
file is no longer an XML source (now path), neither is uri (now URL) - this reduces SP log errors