### PR TITLE
move to the 3.0 namespace

### DIFF
--- a/sp/etc-shibboleth/shibboleth2.xml
+++ b/sp/etc-shibboleth/shibboleth2.xml
@@ -1,5 +1,5 @@
-<SPConfig xmlns="urn:mace:shibboleth:2.0:native:sp:config"
-    xmlns:conf="urn:mace:shibboleth:2.0:native:sp:config"
+<SPConfig xmlns="urn:mace:shibboleth:3.0:native:sp:config"
+    xmlns:conf="urn:mace:shibboleth:3.0:native:sp:config"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"    
     xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"


### PR DESCRIPTION
after removing the deprecated file/uri options - now we are using SP3 , lets migrate to the 3.0 namespace (removes final SP log warnings/errors).