### PR TITLE
Install php-cas from release

### DIFF
--- a/php-cas/Dockerfile
+++ b/php-cas/Dockerfile
@@ -4,12 +4,6 @@ RUN yum -y update \
     && yum -y install ant doxygen git php-pear \
     && yum -y clean all
 
-RUN git clone --depth=1 --branch=1.3-stable https://github.com/apereo/phpCAS.git apereo/phpCAS \
- && pear upgrade --force --alldeps \
- && cd apereo/phpCAS/utils \
- && pear install --onlyreqdeps PEAR_PackageFileManager2-beta \
- && ant dist -Ddoxygen.path=/usr/bin/doxygen -Dphp.path=/usr/bin/php
-
 FROM centos:centos7
 
 MAINTAINER Unicon, Inc.
@@ -18,10 +12,10 @@ RUN yum -y update \
     && yum -y install httpd mod_ssl php php-pear php-xml php-pdo wget \
     && yum -y clean all
 
-COPY --from=stage /apereo/phpCAS/utils/dist/CAS-1.3.4.tgz /
+RUN wget https://github.com/apereo/phpCAS/releases/download/1.3.8/CAS-1.3.8.tgz \
+ && tar zxvpf CAS-1.3.8.tgz
 
-RUN pear install CAS-1.3.4.tgz \
- && rm /CAS-1.3.4.tgz
+RUN pear install CAS-1.3.8.tgz
 
 COPY httpd-foreground /usr/local/bin/
 COPY etc-httpd/ /etc/httpd/


### PR DESCRIPTION
Master doesn't install

```
Step 7/14 : COPY --from=stage /apereo/phpCAS/utils/dist/CAS-1.3.4.tgz /
 ---> 37d7abec43dd
Step 8/14 : RUN pear install CAS-1.3.4.tgz  && rm /CAS-1.3.4.tgz
 ---> Running in ebb913a7d516
could not extract the package.xml file from "CAS-1.3.4.tgz"
install failed
ERROR: Service 'php-cas' failed to build: The command '/bin/sh -c pear install CAS-1.3.4.tgz  && rm /CAS-1.3.4.tgz' returned a non-zero code: 1
```

Added an alternative install which seems to work fine